### PR TITLE
GNOME 47 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "description": "Raise pairs of tiled windows in tandem.",
     "uuid": "tandem-raise@tomdryer.com",
     "url": "https://github.com/tdryer/tandem-raise",
-    "shell-version": ["46"]
+    "shell-version": ["46", "47"]
 }


### PR DESCRIPTION
Update metadata.json to list GNOME 47 as a supported version.